### PR TITLE
Move JWT patch to dependency patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,56 @@
 {
-    "type":"library",
-    "license":"MIT",
-    "name":"concrete5/dependency-patches",
-    "description":"Patches required for concrete5 dependencies",
-    "homepage":"https://github.com/concrete5/dependency-patches",
-    "authors":[
-        {
-            "name":"Michele Locati",
-            "email":"michele@locati.it",
-            "role":"author",
-            "homepage":"https://mlocati.github.io"
-        }
-    ],
-    "require":{
-        "mlocati/composer-patcher": "^1.0.0"
-    },
-    "extra":{
-        "patches": {
-            "doctrine/annotations:1.2.7": {
-                "Fix access array offset on value of type null": "doctrine/annotations/access-array-offset-on-null.patch"
-            },
-            "doctrine/orm:2.5.14": {
-                "Fix UnitOfWork::createEntity()": "doctrine/orm/UnitOfWork-createEntity-continue.patch"
-            },
-            "zendframework/zend-stdlib:2.7.7": {
-                "Fix ArrayObject::unserialize()": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch"
-            },
-            "sunra/php-simple-html-dom-parser:1.5.2": {
-                "Fix minus in regular expressions": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch"
-            },
-            "phpunit/phpunit:4.8.36": {
-                "Avoid each() in Getopt": "phpunit/phpunit/Getopt-each.patch"
-            },
-            "tedivm/jshrink:1.1.0": {
-                "Fix continue switch in Minifier": "tedivm/jshrink/fix-minifier-loop.patch",
-                "Update to upstream version 1.3.2": "tedivm/jshrink/update-upstream-1.3.2.patch"
-            },
-            "zendframework/zend-code:2.6.3": {
-                "Fix continue switch in FileGenerator and MethodReflection": "zendframework/zend-code/switch-continue.patch"
-            },
-            "zendframework/zend-http:2.6.0": {
-                "Remove support for the X-Original-Url and X-Rewrite-Url headers": "zendframework/zend-http/no-x-original-url-x-rewrite.patch"
-            },
-            "zendframework/zend-mail:2.7.3": {
-                "Fix idn_to_ascii deprecation warning": "zendframework/zend-mail/fix-idn_to_ascii-deprecation-warning.patch"
-            },
-            "zendframework/zend-validator:2.8.2": {
-                "Fix idn_to_ascii/idn_to_utf8 deprecation warning": "zendframework/zend-validator/fix-idn_to_-deprecation-warning.patch"
-            }
-        }
+  "type": "library",
+  "license": "MIT",
+  "name": "concrete5/dependency-patches",
+  "description": "Patches required for concrete5 dependencies",
+  "homepage": "https://github.com/concrete5/dependency-patches",
+  "authors": [
+    {
+      "name": "Michele Locati",
+      "email": "michele@locati.it",
+      "role": "author",
+      "homepage": "https://mlocati.github.io"
     }
+  ],
+  "require": {
+    "mlocati/composer-patcher": "^1.0.0"
+  },
+  "extra": {
+    "patches": {
+      "doctrine/annotations:1.2.7": {
+        "Fix access array offset on value of type null": "doctrine/annotations/access-array-offset-on-null.patch"
+      },
+      "doctrine/orm:2.5.14": {
+        "Fix UnitOfWork::createEntity()": "doctrine/orm/UnitOfWork-createEntity-continue.patch"
+      },
+      "zendframework/zend-stdlib:2.7.7": {
+        "Fix ArrayObject::unserialize()": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch"
+      },
+      "sunra/php-simple-html-dom-parser:1.5.2": {
+        "Fix minus in regular expressions": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch"
+      },
+      "phpunit/phpunit:4.8.36": {
+        "Avoid each() in Getopt": "phpunit/phpunit/Getopt-each.patch"
+      },
+      "tedivm/jshrink:1.1.0": {
+        "Fix continue switch in Minifier": "tedivm/jshrink/fix-minifier-loop.patch",
+        "Update to upstream version 1.3.2": "tedivm/jshrink/update-upstream-1.3.2.patch"
+      },
+      "zendframework/zend-code:2.6.3": {
+        "Fix continue switch in FileGenerator and MethodReflection": "zendframework/zend-code/switch-continue.patch"
+      },
+      "zendframework/zend-http:2.6.0": {
+        "Remove support for the X-Original-Url and X-Rewrite-Url headers": "zendframework/zend-http/no-x-original-url-x-rewrite.patch"
+      },
+      "zendframework/zend-mail:2.7.3": {
+        "Fix idn_to_ascii deprecation warning": "zendframework/zend-mail/fix-idn_to_ascii-deprecation-warning.patch"
+      },
+      "zendframework/zend-validator:2.8.2": {
+        "Fix idn_to_ascii/idn_to_utf8 deprecation warning": "zendframework/zend-validator/fix-idn_to_-deprecation-warning.patch"
+      },
+      "lcobucci/jwt:3.4.5": {
+        "Adds php 8 compability to jwt version 3.4.5": "lcobucci/jwt/php8-compatibility.patch"
+      }
+    }
+  }
 }

--- a/lcobucci/jwt/php8-compatibility.patch
+++ b/lcobucci/jwt/php8-compatibility.patch
@@ -1,0 +1,57 @@
+From a61e8f46e78d511b5c0678189e3a86de226b7c7c Mon Sep 17 00:00:00 2001
+From: Derek Cameron <derek@concrete5.co.jp>
+Date: Tue, 14 Sep 2021 20:01:22 +0900
+Subject: [PATCH] PHP8 Compatibility changes from Auth0
+
+---
+ src/Signer/OpenSSL.php | 17 ++++++++++++++---
+ 1 file changed, 14 insertions(+), 3 deletions(-)
+
+diff --git a/src/Signer/OpenSSL.php b/src/Signer/OpenSSL.php
+index 1c7706cc..f598c530 100644
+--- a/src/Signer/OpenSSL.php
++++ b/src/Signer/OpenSSL.php
+@@ -13,6 +13,13 @@
+
+ abstract class OpenSSL extends BaseSigner
+ {
++    private $phpVersion8 = false;
++
++    public function __construct()
++    {
++        $this->phpVersion8 = (PHP_MAJOR_VERSION >= 8);
++    }
++
+     public function createHash($payload, Key $key)
+     {
+         $privateKey = $this->getPrivateKey($key->getContent(), $key->getPassphrase());
+@@ -26,7 +33,9 @@ public function createHash($payload, Key $key)
+
+             return $signature;
+         } finally {
+-            openssl_free_key($privateKey);
++            if (!$this->phpVersion8) {
++                openssl_free_key($privateKey);
++            }
+         }
+     }
+
+@@ -54,7 +63,9 @@ public function doVerify($expected, $payload, Key $key)
+     {
+         $publicKey = $this->getPublicKey($key->getContent());
+         $result    = openssl_verify($payload, $expected, $publicKey, $this->getAlgorithm());
+-        openssl_free_key($publicKey);
++        if (!$this->phpVersion8) {
++            openssl_free_key($publicKey);
++        }
+
+         return $result === 1;
+     }
+@@ -81,7 +92,7 @@ private function getPublicKey($pem)
+      */
+     private function validateKey($key)
+     {
+-        if (! is_resource($key)) {
++        if (($this->phpVersion8 && $key === false) || (!$this->phpVersion8 && !is_resource($key))) {
+             throw InvalidKeyProvided::cannotBeParsed(openssl_error_string());
+         }


### PR DESCRIPTION
Currently in version 9.0rc branch we have php8 compatibility, this is done with a patch for lcobucci/jwt package (As version 3.4.5 supports php 7.3/7.4 and 4.0 and above support only php7.4/8.*)

This PR adds that patch to this repository, once a new version of dependency patches is released we can remove that patch from the core repository. 

