### PR TITLE
Fix wrong conversion in Gettext PhpCode extractor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "Fix access array offset on value of type null": "egulias/email-validator/access-array-offset-on-null.patch"
       },
       "gettext/gettext:3.5.9": {
-        "Fix PHP 8 compatibility": "gettext/gettext/php8-compatibility.patch"
+        "Fix PHP 8 compatibility": "gettext/gettext/php8-compatibility.patch",
+        "Fix wrong conversion in PhpCode": "gettext/gettext/fix-wrong-conversion.patch"
       },
       "laminas/laminas-code:3.4.1": {
         "Add PHP 8.1 compatibility": "laminas/laminas-code/php8.1-compatibility.patch"

--- a/gettext/gettext/fix-wrong-conversion.patch
+++ b/gettext/gettext/fix-wrong-conversion.patch
@@ -1,0 +1,22 @@
+From: Remi Collet <remi@remirepo.net>
+Date: Thu, 10 Oct 2019 16:28:19 +0200
+Subject: [PATCH] Fix Invalid characters passed for attempted conversion (7.4)
+
+
+--- a/src/Extractors/PhpCode.php
++++ b/src/Extractors/PhpCode.php
+@@ -87,11 +87,11 @@ class PhpCode extends Extractor implements ExtractorInterface
+                 case '\\':
+                     return '\\';
+                 case 'x':
+-                    return chr(hexdec(substr($match[0], 1)));
++                    return chr(hexdec(substr($match[1], 1)));
+                 case 'u':
+-                    return self::unicodeChar(hexdec(substr($match[0], 1)));
++                    return self::unicodeChar(hexdec(substr($match[1], 1)));
+                 default:
+-                    return chr(octdec($match[0]));
++                    return chr(octdec($match[1]));
+             }
+         }, $value);
+     }


### PR DESCRIPTION
Let's get rid of this warning:

```
PHP Deprecated:  Invalid characters passed for attempted conversion,
these have been ignored in src/Extractors/PhpCode.php on line 90
```

(which reports a bug in the code)